### PR TITLE
systemd service: use `Type=exec`

### DIFF
--- a/systemd/balance-subscriber.service
+++ b/systemd/balance-subscriber.service
@@ -10,7 +10,8 @@ ExecStart=/opt/balance-subscriber/venv/bin/balance-subscriber
 # Automatically restart the service if it crashes
 Restart=on-failure
 # Our service will notify systemd once it is up and running
-Type=notify
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Type=
+Type=exec
 # Use a dedicated user to run our service
 User=balance-subscriber
 


### PR DESCRIPTION
This means that that the service doesn't need to notify systemd that it's started.

> The exec type is similar to simple, but the service manager will consider the unit started immediately after the main service binary has been executed. The service manager will delay starting of follow-up units until that point. (Or in other words: simple proceeds with further jobs right after fork() returns, while exec will not proceed before both fork() and execve() in the service process succeeded.) Note that this means systemctl start command lines for exec services will report failure when the service's binary cannot be invoked successfully (for example because the selected User= doesn't exist, or the service binary is missing).

https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Type=